### PR TITLE
fix: Add the SHALLOW_RELOAD_MIGRATION configuration key

### DIFF
--- a/django/conf/global_settings.py
+++ b/django/conf/global_settings.py
@@ -643,6 +643,11 @@ STATICFILES_FINDERS = [
 # Migration module overrides for apps, by app label.
 MIGRATION_MODULES = {}
 
+# Only generate first degree relations between tables when building the project
+# state. This speeds up migration but can be dangerous.
+# See https://forum.djangoproject.com/t/very-slow-migrations-with-large-numbers-of-tables/29038/7
+SHALLOW_RELOAD_MIGRATION = False
+
 #################
 # SYSTEM CHECKS #
 #################

--- a/django/db/migrations/migration.py
+++ b/django/db/migrations/migration.py
@@ -1,5 +1,11 @@
 import re
 
+from django.conf import settings
+from django.db.migrations.operations.special import (
+    RunPython,
+    RunSQL,
+    SeparateDatabaseAndState,
+)
 from django.db.migrations.utils import get_migration_name_timestamp
 from django.db.transaction import atomic
 
@@ -101,6 +107,16 @@ class Migration:
         Migrations.
         """
         for operation in self.operations:
+            ###################################################################
+            ## Patch START
+            if settings.SHALLOW_RELOAD_MIGRATION and (
+                isinstance(operation, SeparateDatabaseAndState)
+                or isinstance(operation, RunSQL)
+                or isinstance(operation, RunPython)
+            ):
+                project_state.reload_models(models=None)
+            ## Patch END
+            ###################################################################
             # If this operation cannot be represented as SQL, place a comment
             # there instead
             if collect_sql:

--- a/django/db/migrations/state.py
+++ b/django/db/migrations/state.py
@@ -396,17 +396,47 @@ class ProjectState:
 
     def reload_model(self, app_label, model_name, delay=False):
         if "apps" in self.__dict__:  # hasattr would cache the property
-            related_models = self._find_reload_model(app_label, model_name, delay)
-            self._reload(related_models)
+            ###################################################################
+            ## Old code
+            # related_models = self._find_reload_model(app_label, model_name, delay)
+            # self._reload(related_models)
+            ## Patch START
+            if settings.SHALLOW_RELOAD_MIGRATION:
+                self._reload(set([(app_label, model_name)]))
+            else:
+                related_models = self._find_reload_model(app_label, model_name, delay)
+                self._reload(related_models)
+            ## Patch END
+            ###################################################################
 
     def reload_models(self, models, delay=True):
         if "apps" in self.__dict__:  # hasattr would cache the property
-            related_models = set()
-            for app_label, model_name in models:
-                related_models.update(
-                    self._find_reload_model(app_label, model_name, delay)
-                )
-            self._reload(related_models)
+            ###################################################################
+            ## Old code
+            # related_models = set()
+            # for app_label, model_name in models:
+            #     related_models.update(
+            #         self._find_reload_model(app_label, model_name, delay)
+            #     )
+            ## Patch START
+            if settings.SHALLOW_RELOAD_MIGRATION:
+                if models is None:
+                    related_models = set(self.models.keys())
+                else:
+                    related_models = set()
+                    for app_label, model_name in models:
+                        related_models.update(
+                            self._find_reload_model(app_label, model_name, delay)
+                        )
+                self._reload(related_models)
+            else:
+                related_models = set()
+                for app_label, model_name in models:
+                    related_models.update(
+                        self._find_reload_model(app_label, model_name, delay)
+                    )
+            ## Patch END
+            ###################################################################
 
     def _reload(self, related_models):
         # Unregister all related models


### PR DESCRIPTION
When SHALLOW_RELOAD_MIGRATION is set to True, Only generate first degree relations between tables when building the project state. This speeds up migration but can be dangerous.  See
https://forum.djangoproject.com/t/very-slow-migrations-with-large-numbers-of-tables/29038/7

Issue: DXG-914
